### PR TITLE
Make #menu adapt to length of link translations

### DIFF
--- a/adminer.css
+++ b/adminer.css
@@ -216,7 +216,7 @@ p code + a:visited:hover {
 }
 
 #menu {
-	width: 347px;
+	width: auto;
 	border-right: 1px solid #dae8fa;
 	box-shadow: inset -1px 0 0 #fff;
 	margin: 0;


### PR DESCRIPTION
In a few languages, e.g. German, the translation of the action links takes more space than the fixed 347px `#menu` width provides. Setting this width to auto lets the menu automatically adapt: more space for space-saving languages, nice rendering for those with longer words.